### PR TITLE
Add cache for forecast

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,12 @@
 from lib.forecast import Forecast
 from lib.sensors import Sensors
 from flask import Flask, render_template
+from flask_caching import Cache
 
 app = Flask(__name__)
+app.config["CACHE_TYPE"] = "simple"
 app.config.from_prefixed_env()
+cache = Cache(app)
 
 
 @app.route("/")
@@ -17,5 +20,11 @@ def sensors():
 
 
 @app.route("/forecast")
+@cache.cached(timeout=(600))
 def forecast():
+    """
+    Cache of 10 minutes is so that the api endpoint for tomorrow.io doesn't get
+    hit too frequently. As of 2025-02-02 the limits for the api key are:
+    3 requests/second; 25 requests/hour; 500 requests/day.
+    """
     return Forecast.fetch().output()

--- a/env.example
+++ b/env.example
@@ -1,1 +1,2 @@
 TOMORROW_API_KEY="your_api_key"
+SENSOR_API_URL="http://your_sensor_api_url/api/sensors"

--- a/lib/services.py
+++ b/lib/services.py
@@ -9,6 +9,8 @@ class Services:
 
 
 S = Services(
-    sensor_api_url=os.getenv("SENSOR_API_URL", "http://galilei:8888/api/sensors"),
+    sensor_api_url=os.getenv(
+        "SENSOR_API_URL", "http://your_sensor_api_url/api/sensors"
+    ),
     tomorrow_api_key=os.getenv("TOMORROW_API_KEY", "your_api_key"),
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -28,6 +28,17 @@ files = [
 ]
 
 [[package]]
+name = "cachelib"
+version = "0.9.0"
+description = "A collection of cache libraries in the same API interface."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachelib-0.9.0-py3-none-any.whl", hash = "sha256:811ceeb1209d2fe51cd2b62810bd1eccf70feba5c52641532498be5c675493b3"},
+    {file = "cachelib-0.9.0.tar.gz", hash = "sha256:38222cc7c1b79a23606de5c2607f4925779e37cdcea1c2ad21b8bae94b5425a5"},
+]
+
+[[package]]
 name = "certifi"
 version = "2023.11.17"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -183,6 +194,21 @@ Werkzeug = ">=3.0.0"
 [package.extras]
 async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
+
+[[package]]
+name = "flask-caching"
+version = "2.3.0"
+description = "Adds caching support to Flask applications."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Flask_Caching-2.3.0-py3-none-any.whl", hash = "sha256:51771c75682e5abc1483b78b96d9131d7941dc669b073852edfa319dd4e29b6e"},
+    {file = "flask_caching-2.3.0.tar.gz", hash = "sha256:d7e4ca64a33b49feb339fcdd17e6ba25f5e01168cf885e53790e885f83a4d2cf"},
+]
+
+[package.dependencies]
+cachelib = ">=0.9.0,<0.10.0"
+Flask = "*"
 
 [[package]]
 name = "flask-socketio"
@@ -518,4 +544,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "315ce8295b4788c9c346ad591be34b4bd285cc2686c79fd4322d4d6ae745596a"
+content-hash = "48bf1e8292e488d2557adf8d25c01e99f4333515d75b000556ef92b5e7a468bf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python-dateutil = "^2.8.2"
 requests = "^2.31.0"
 python-dotenv = "^1.0.0"
 gunicorn = "^21.2.0"
+flask-caching = "^2.3.0"
 
 
 [build-system]

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/bash
 
+npm run build
 poetry run gunicorn --config wsgi.py app:app


### PR DESCRIPTION
This adds a cache to the forecast route so that we don't hit the tomorrow.io api too frequently. 

The cache is around the route because I don't know how to import the the cache from `app.py` into `forecast.py` without having circular imports. There's probably a way to do it, but I don't think it's worth it right now. Having the cache on the route (while more than necessary) has the advantage of being obvious about what's going on. 

It also adds `npm run build` to the `run.sh` script.